### PR TITLE
add configuration to help GloBI index EuPPollNet

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,41 @@
+# This workflow will review a GloBI indexed dataset.
+# For more information see: https://globalbioticinteractions.org
+
+name: GloBI review by Elton
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+  schedule:
+    - cron: "0 0 * * 1"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - name: download review script
+        run: curl --silent -L "https://raw.githubusercontent.com/globalbioticinteractions/globinizer/master/check-dataset.sh" > check-dataset.sh
+      - name: download network compiler script
+        run: |
+          curl --silent -L "https://raw.githubusercontent.com/globalbioticinteractions/globinizer/master/compile-network.sh" > compile-network.sh
+          chmod +x compile-network.sh
+      - name: review dataset
+        run: bash check-dataset.sh "${GITHUB_REPOSITORY}"
+      - name: Share review report
+        uses: actions/upload-artifact@v4
+        with:
+          name: review-report
+          path: |
+            README.txt
+            datasets/
+            index.*
+            indexed-*
+            review*

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,4 @@ Data/Interactions_uncounted_uncompressed.rds
 Data/Working_files/Raster_Europe/
 Data/Working_files/Bio_Regions/
 Data/Working_files/Natura_2000/
-
-
+datasets/

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ matrices_list = map(long_format_list, sum_interactions)
 
 If you use this database in your research, please make sure to cite this data paper.
 
+### Indexing
+
+[![GloBI Review by Elton](../../actions/workflows/review.yml/badge.svg)](../../actions/workflows/review.yml) [![GloBI](https://api.globalbioticinteractions.org/interaction.svg?accordingTo=globi:JoseBSL/EuPPollNet&refutes=true&refutes=false)](https://globalbioticinteractions.org/?accordingTo=globi:JoseBSL/EuPPollNet)
+
+EuPPollNet is configured to be indexed by Global Biotic Interactions (GloBI, https://globalbioticinteractions.org).
 
 
 

--- a/globi.json
+++ b/globi.json
@@ -1,0 +1,244 @@
+{
+  "@context" : [ "http://www.w3.org/ns/csvw", {
+    "@language" : "en"
+  } ],
+  "rdfs:comment" : [ "inspired by https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/" ],
+  "tables" : [ {
+    "@context" : [ "http://www.w3.org/ns/csvw", {
+      "@language" : "en"
+    } ],
+    "rdfs:comment" : [ "inspired by https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/" ],
+    "url" : "Data/3_Final_data/Metadata.csv",
+    "dcterms:bibliographicCitation" : "Lanuza et al. (2025), EuPPollNet: A European Database of Plant-Pollinator Networks. Global Ecol Biogeogr, 34: e70000. https://doi.org/10.1111/geb.70000",
+    "delimiter" : ",",
+    "headerRowCount" : 1,
+    "null" : [ "" ],
+    "tableSchema" : {
+      "primaryKey": "referenceId",
+      "columns" : [ {
+        "name" : "Study_number",
+        "titles" : "Study_number",
+        "datatype" : "string"
+      }, {
+        "name" : "referenceId",
+        "titles" : "Study_id",
+        "datatype" : "string"
+      }, {
+        "name" : "referenceDoi",
+        "titles" : "DOI",
+        "datatype" : "string"
+      }, {
+        "name" : "Year",
+        "titles" : "Year",
+        "datatype" : "string"
+      }, {
+        "name" : "basisOfRecordName",
+        "titles" : "Sampling_method",
+        "datatype" : "string"
+      }, {
+        "name" : "Min_date",
+        "titles" : "Min_date",
+        "datatype" : "string"
+      }, {
+        "name" : "Max_date",
+        "titles" : "Max_date",
+        "datatype" : "string"
+      }, {
+        "name" : "Sampling_days",
+        "titles" : "Sampling_days",
+        "datatype" : "string"
+      }, {
+        "name" : "Sampling_period",
+        "titles" : "Sampling_period",
+        "datatype" : "string"
+      }, {
+        "name" : "Hymenoptera_percent",
+        "titles" : "Hymenoptera_percent",
+        "datatype" : "string"
+      }, {
+        "name" : "Diptera_percent",
+        "titles" : "Diptera_percent",
+        "datatype" : "string"
+      }, {
+        "name" : "Lepidoptera_percent",
+        "titles" : "Lepidoptera_percent",
+        "datatype" : "string"
+      }, {
+        "name" : "Coleoptera_percent",
+        "titles" : "Coleoptera_percent",
+        "datatype" : "string"
+      }, {
+        "name" : "Number_of_main_orders_recorded",
+        "titles" : "Number_of_main_orders_recorded",
+        "datatype" : "string"
+      }, {
+        "name" : "Other_orders",
+        "titles" : "Other_orders",
+        "datatype" : "string"
+      }, {
+        "name" : "Total_interactions",
+        "titles" : "Total_interactions",
+        "datatype" : "string"
+      }, {
+        "name" : "Taxa_recorded",
+        "titles" : "Taxa_recorded",
+        "datatype" : "string"
+      }, {
+        "name" : "Coauthor_Names",
+        "titles" : "Coauthor_Names",
+        "datatype" : "string"
+      }, {
+        "name" : "Orcids",
+        "titles" : "Orcids",
+        "datatype" : "string"
+      }, {
+        "name" : "Emails",
+        "titles" : "Emails",
+        "datatype" : "string"
+      } ]
+    }
+  },
+  {
+    "@context" : [ "http://www.w3.org/ns/csvw", {
+      "@language" : "en"
+    } ],
+    "rdfs:comment" : [ "inspired by https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/" ],
+    "url" : "Data/3_Final_data/Interaction_data.csv.gz",
+    "dcterms:bibliographicCitation" : "Lanuza et al. (2025), EuPPollNet: A European Database of Plant-Pollinator Networks. Global Ecol Biogeogr, 34: e70000. https://doi.org/10.1111/geb.70000",
+    "delimiter" : ",",
+    "headerRowCount" : 1,
+    "null" : [ "" ],
+    "interactionTypeName": "pollinatedBy",
+    "interactionTypeId": "http://purl.obolibrary.org/obo/RO_0002456",
+    "tableSchema" : {
+      "foreignKeys": [{
+        "columnReference": "referenceId",
+        "reference": {
+          "resource": "Data/3_Final_data/Metadata.tsv",
+          "columnReference": "referenceId"
+        }
+      }],
+      "columns" : [ {
+        "name" : "referenceId",
+        "titles" : "Study_id",
+        "datatype" : "string"
+      }, {
+        "name" : "networkId",
+        "titles" : "Network_id",
+        "datatype" : "string"
+      }, {
+        "name" : "Sampling_method",
+        "titles" : "Sampling_method",
+        "datatype" : "string"
+      }, {
+        "name" : "Authors_habitat",
+        "titles" : "Authors_habitat",
+        "datatype" : "string"
+      }, {
+        "name" : "EuPPollNet_habitat",
+        "titles" : "EuPPollNet_habitat",
+        "datatype" : "string"
+      }, {
+        "name" : "Bioregion",
+        "titles" : "Bioregion",
+        "datatype" : "string"
+      }, {
+        "name" : "Country",
+        "titles" : "Country",
+        "datatype" : "string"
+      }, {
+        "name" : "localityName",
+        "titles" : "Locality",
+        "datatype" : "string"
+      }, {
+        "name" : "decimalLatitude",
+        "titles" : "Latitude",
+        "datatype" : "string"
+      }, {
+        "name" : "decimalLongitude",
+        "titles" : "Longitude",
+        "datatype" : "string"
+      }, {
+        "name" : "http://rs.tdwg.org/dwc/terms/eventDate",
+        "titles" : "Date",
+        "datatype" : "string"
+      }, {
+        "name" : "Interaction",
+        "titles" : "Interaction",
+        "datatype" : "string"
+      }, {
+        "name" : "sourceTaxonNameVerbatim",
+        "titles" : "Plant_original_name",
+        "datatype" : "string"
+      }, {
+        "name" : "sourceTaxonName",
+        "titles" : "Plant_accepted_name",
+        "datatype" : "string"
+      }, {
+        "name" : "sourceTaxonRankName",
+        "titles" : "Plant_rank",
+        "datatype" : "string"
+      }, {
+        "name" : "sourceTaxonOrderName",
+        "titles" : "Plant_order",
+        "datatype" : "string"
+      }, {
+        "name" : "sourceTaxonFamilyName",
+        "titles" : "Plant_family",
+        "datatype" : "string"
+      }, {
+        "name" : "sourceTaxonGenusName",
+        "titles" : "Plant_genus",
+        "datatype" : "string"
+      }, {
+        "name" : "Plant_unsure_id",
+        "titles" : "Plant_unsure_id",
+        "datatype" : "string"
+      }, {
+        "name" : "Plant_uncertainty_type",
+        "titles" : "Plant_uncertainty_type",
+        "datatype" : "string"
+      }, {
+        "name" : "targetTaxonNameVerbatim",
+        "titles" : "Pollinator_original_name",
+        "datatype" : "string"
+      }, {
+        "name" : "targetTaxonName",
+        "titles" : "Pollinator_accepted_name",
+        "datatype" : "string"
+      }, {
+        "name" : "targetTaxonRankName",
+        "titles" : "Pollinator_rank",
+        "datatype" : "string"
+      }, {
+        "name" : "targetTaxonOrderName",
+        "titles" : "Pollinator_order",
+        "datatype" : "string"
+      }, {
+        "name" : "targetTaxonFamilyName",
+        "titles" : "Pollinator_family",
+        "datatype" : "string"
+      }, {
+        "name" : "targetTaxonGenusName",
+        "titles" : "Pollinator_genus",
+        "datatype" : "string"
+      }, {
+        "name" : "Pollinator_unsure_id",
+        "titles" : "Pollinator_unsure_id",
+        "datatype" : "string"
+      }, {
+        "name" : "Pollinator_uncertainty_type",
+        "titles" : "Pollinator_uncertainty_type",
+        "datatype" : "string"
+      }, {
+        "name" : "Flower_data",
+        "titles" : "Flower_data",
+        "datatype" : "string"
+      }, {
+        "name" : "Flower_data_merger",
+        "titles" : "Flower_data_merger",
+        "datatype" : "string"
+      } ]
+    }
+  } ]
+}


### PR DESCRIPTION
Thanks @JoseBSL for your prompt communication.

Please review this pull request with changes to let GloBI index your vast plant-pollinator database. With this, GloBI will keep track of your changes and include them into future versions of the search index / data reviews.

related to https://github.com/globalbioticinteractions/globalbioticinteractions/issues/1041 and https://github.com/JoseBSL/EuPPollNet/issues/8#issuecomment-2635058761 - Towards indexing Lanuza et al. (2025), EuPPollNet: A European Dat…abase of Plant-Pollinator Networks. Global Ecol Biogeogr, 34: e70000. https://doi.org/10.1111/geb.70000 

For a preliminary data review, please see attached 
[index.pdf](https://github.com/user-attachments/files/18663366/index.pdf) . For full review, see temporary download link at https://send.tresorit.com/a#p8BkjdQzWthuU1Tl4VrnMQ .

Thanks for all your hard work and let me know if you have any questions / comments / suggestions. 
